### PR TITLE
Add support for pry-stack_explorer in pry_debugger

### DIFF
--- a/lib/pry-debugger/before_session_hook.rb
+++ b/lib/pry-debugger/before_session_hook.rb
@@ -1,0 +1,26 @@
+module PryDebugger
+  class BeforeSessionHook
+
+    def caller_bindings(target)
+
+      bindings = binding.callers
+
+      start_frames = bindings.each_with_index.select do |b, i|
+        (b.frame_type == :method &&
+         b.eval("self.class") == Debugger::Context &&
+         b.eval("__method__") == :at_line)
+      end
+
+      start_frame_index = start_frames.first.last
+      bindings = bindings.drop(start_frame_index + 1)
+
+      bindings
+    end
+
+    def call(output, target, _pry_)
+      return if binding.callers.map(&:frame_description).include?("start")
+		  bindings = caller_bindings(target)
+      PryStackExplorer.create_and_push_frame_manager bindings, _pry_, :initial_frame => 0
+    end
+  end
+end

--- a/lib/pry-debugger/cli.rb
+++ b/lib/pry-debugger/cli.rb
@@ -11,5 +11,6 @@
 #
 
 require 'pry-debugger/base'
+require 'pry-debugger/before_session_hook.rb'
 require 'pry-debugger/pry_ext'
 require 'pry-debugger/commands'

--- a/lib/pry-debugger/pry_ext.rb
+++ b/lib/pry-debugger/pry_ext.rb
@@ -20,3 +20,12 @@ class << Pry
     end
   end
 end
+
+if Pry.plugins.include?("stack_explorer")
+  Pry.config.hooks.add_hook(:before_session, :debugger_frame_manager, PryDebugger::BeforeSessionHook.new)
+
+  # move default to the back of before_session
+  default = Pry.config.hooks.get_hook(:before_session, :default)
+  Pry.config.hooks.delete_hook(:before_session, :default)
+  Pry.config.hooks.add_hook(:before_session, :default, default)
+end


### PR DESCRIPTION
At the moment, the frame_manager is initialized when a pry session starts, but destroyed every time repl is left. This patch, adds a hook to before_session, so that a new frame_manager can be created from within the debugger. 
