### PR TITLE
Safer monkey-patching of Pry.start/.teardown

### DIFF
--- a/lib/pry-debugger/pry_ext.rb
+++ b/lib/pry-debugger/pry_ext.rb
@@ -2,21 +2,22 @@ require 'pry'
 require 'pry-debugger/processor'
 
 class << Pry
-  alias_method :start_existing, :start
+  alias_method :start_without_pry_debugger, :start
   attr_reader :processor
 
-  def start(target = TOPLEVEL_BINDING, options = {})
+  def start_with_pry_debugger(target = TOPLEVEL_BINDING, options = {})
     @processor ||= PryDebugger::Processor.new
 
     if target.is_a?(Binding) && PryDebugger.check_file_context(target)
       # Wrap the processer around the usual Pry.start to catch navigation
       # commands.
       @processor.run(true) do
-        start_existing(target, options)
+        start_without_pry_debugger(target, options)
       end
     else
       # No need for the tracer unless we have a file context to step through
-      start_existing(target, options)
+      start_without_pry_debugger(target, options)
     end
   end
+  alias_method :start, :start_with_pry_debugger
 end

--- a/lib/pry-debugger/pry_remote_ext.rb
+++ b/lib/pry-debugger/pry_remote_ext.rb
@@ -19,14 +19,15 @@ module PryRemote
     end
 
     # Override to reset our saved global current server session.
-    alias_method :teardown_existing, :teardown
-    def teardown
+    alias_method :teardown_without_pry_debugger, :teardown
+    def teardown_with_pry_debugger
       return if @torn
 
-      teardown_existing
+      teardown_without_pry_debugger
       PryDebugger.current_remote_server = nil
       @torn = true
     end
+    alias_method :teardown, :teardown_with_pry_debugger
   end
 end
 


### PR DESCRIPTION
Allows other plugins to do the same without triggering a SystemStackError.
