### PR TITLE
allow breaking on REPL-defined mehods

### DIFF
--- a/lib/pry-debugger/breakpoints.rb
+++ b/lib/pry-debugger/breakpoints.rb
@@ -10,11 +10,15 @@ module PryDebugger
 
     # Add a new breakpoint.
     def add(file, line, expression = nil)
-      raise ArgumentError, 'Invalid file!' unless File.exist?(file)
+      if !File.exist?(file) && file != Pry.eval_path
+        raise ArgumentError, 'Invalid file!' unless File.exist?(file)
+      end
       validate_expression expression
 
       Pry.processor.debugging = true
-      Debugger.add_breakpoint(File.expand_path(file), line, expression)
+
+      path = file == Pry.eval_path ? file : File.expand_path(file)
+      Debugger.add_breakpoint(path, line, expression)
     end
 
     # Change the conditional expression for a breakpoint.


### PR DESCRIPTION
``` ruby
[1] pry(main)> def hello
             |   puts "hi"
             | end  
=> nil
[2] pry(main)> break hello
Breakpoint 1: (pry) @ line 1 (Enabled) :

 => 1: def hello
    2:   puts "hi"
    3: end

[3] pry(main)> hello

Breakpoint 1. First hit.

Frame number: 0/5

From: (pry) @ line 1 Object#hello:

 => 1: def hello
    2:   puts "hi"
    3: end

[4] pry(main)> next
```
