### PR TITLE
Add standard aliases for continue, step, next, finish commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Using Pry with Rails? Check out [Jazz Hands][jazz_hands].
 
 ## Tips
 
+_Note: The following aliases are natively supported since 0.2.3_
+
 Stepping through code often? Add the following shortcuts to `~/.pryrc`:
 
 ```ruby

--- a/lib/pry-debugger/commands.rb
+++ b/lib/pry-debugger/commands.rb
@@ -8,6 +8,7 @@ module PryDebugger
 
       banner <<-BANNER
         Usage: step [TIMES]
+        Aliases: s
 
         Step execution forward. By default, moves a single step.
 
@@ -22,6 +23,7 @@ module PryDebugger
         breakout_navigation :step, args.first
       end
     end
+    alias_command 's', 'step'
 
 
     create_command 'next' do
@@ -29,6 +31,7 @@ module PryDebugger
 
       banner <<-BANNER
         Usage: next [LINES]
+        Aliases: n
 
         Step over within the same frame. By default, moves forward a single
         line.
@@ -44,26 +47,36 @@ module PryDebugger
         breakout_navigation :next, args.first
       end
     end
+    alias_command 'n', 'next'
 
 
     create_command 'finish' do
       description 'Execute until current stack frame returns.'
+      banner <<-BANNER
+        Aliases: f
+      BANNER
 
       def process
         check_file_context
         breakout_navigation :finish
       end
     end
+    alias_command 'f', 'finish'
 
 
     create_command 'continue' do
       description 'Continue program execution and end the Pry session.'
+      banner <<-BANNER
+        Aliases: c
+      BANNER
+
 
       def process
         check_file_context
         run 'exit-all'
       end
     end
+    alias_command 'c', 'continue'
 
 
     create_command 'break' do


### PR DESCRIPTION
Natively support aliases for standard ruby-debug commands

```
`c` for `continue`
`s` for `step`
`n` for `next`
`f` for `finish`
```

I thought it would be convenient for the above aliases to be natively supported instead of maintaining and moving around the corresponding configuration section of ~/.pryrc.

Thanks

--j
