### PR TITLE
Allow pry versions greater than 0.9.x

### DIFF
--- a/pry-debugger.gemspec
+++ b/pry-debugger.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.9.2'
-  gem.add_runtime_dependency 'pry', '~> 0.9.10'
+  gem.add_runtime_dependency 'pry', '>= 0.9.10'
   gem.add_runtime_dependency 'debugger', '~> 1.3'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
Without this, we can't release a pry 1.0.0pre1, for example.
