### PR TITLE
Use debugger aliases only when pry-debugger is available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,12 @@ Using Pry with Rails? Check out [Jazz Hands][jazz_hands].
 Stepping through code often? Add the following shortcuts to `~/.pryrc`:
 
 ```ruby
-Pry.commands.alias_command 'c', 'continue'
-Pry.commands.alias_command 's', 'step'
-Pry.commands.alias_command 'n', 'next'
-Pry.commands.alias_command 'f', 'finish'
+if defined?(PryDebugger)
+  Pry.commands.alias_command 'c', 'continue'
+  Pry.commands.alias_command 's', 'step'
+  Pry.commands.alias_command 'n', 'next'
+  Pry.commands.alias_command 'f', 'finish'
+end
 ```
 
 


### PR DESCRIPTION
Currently, if pry-debugger is not installed, adding these bits to ~/.pryrc makes it show a warning: `error loading ~/.pryrc: undefined method 'options' for nil:NilClass`.

This small tweak makes pry try to set up the debugger aliases only if PryDebugger is available, thus hiding the error when it's not.
