### PR TITLE
debugger recommend using byebug for ruby 2.x

### DIFF
--- a/pry-debugger.gemspec
+++ b/pry-debugger.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   # Dependencies
   gem.required_ruby_version = '>= 1.9.2'
   gem.add_runtime_dependency 'pry', '>= 0.9.10'
-  gem.add_runtime_dependency 'debugger', '~> 1.3'
+  gem.add_runtime_dependency 'byebug', '~> 3.1.2'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
See comment here by cldwalker. Debugger not compatible with Ruby 2.x:
https://github.com/cldwalker/debugger/issues/125
Should fix #52 
